### PR TITLE
tweak section width

### DIFF
--- a/src/components/Section/index.scss
+++ b/src/components/Section/index.scss
@@ -50,6 +50,10 @@
     flex-direction: row;
     height: 600px;
 
+    & .background {
+      width: auto;
+    }
+
     & .section-text {
       padding: 6rem;
       display: flex;


### PR DESCRIPTION
The `width` of `section-container background` has been set to `auto` on mobile view to keep the ratio between image and text section.